### PR TITLE
Providing for the use of context document as input to saxon.xqy

### DIFF
--- a/xbin/saxon.xqy
+++ b/xbin/saxon.xqy
@@ -67,7 +67,10 @@ declare variable $marcxmluri as xs:string external;
 :)
 declare variable $serialization as xs:string external;
 
-let $marcxml := fn:doc($marcxmluri)//marcxml:record
+let $marcxml := if ($marcxmluri) then
+                    fn:doc($marcxmluri)//marcxml:record
+                else
+                    //marcxml:record
 
 let $resources :=
     for $r in $marcxml

--- a/xbin/saxon.xqy
+++ b/xbin/saxon.xqy
@@ -60,6 +60,7 @@ declare variable $baseuri as xs:string external;
 (:~
 :   This variable is for the MARCXML location - externally defined.
 :)
+declare option saxon:default """NONE""";
 declare variable $marcxmluri as xs:string external;
 
 (:~
@@ -67,10 +68,11 @@ declare variable $marcxmluri as xs:string external;
 :)
 declare variable $serialization as xs:string external;
 
-let $marcxml := if ($marcxmluri) then
+let $marcxml := if ($marcxmluri ne "NONE") then
                     fn:doc($marcxmluri)//marcxml:record
                 else
                     //marcxml:record
+
 
 let $resources :=
     for $r in $marcxml


### PR DESCRIPTION
See #79.
