### PR TITLE
debug convert-saxon.sh script

### DIFF
--- a/bin/convert-saxon.sh
+++ b/bin/convert-saxon.sh
@@ -15,7 +15,7 @@ function die {
     exit 1
 }
 function valid_serialization {
-    case $1 in 
+    case $1 in
         rdfxml) return 0 ;;
         rdfxml-raw) return 0 ;;
         ntriples) return 0 ;;
@@ -24,7 +24,7 @@ function valid_serialization {
     esac
     return 1
 }
-        
+
 
 while getopts "s:u:j:" arg; do
     case $arg in
@@ -37,7 +37,7 @@ done
 
 shift $((OPTIND-1))
 
-if [ $# -ne 2 ]; then 
+if [ $# -ne 2 ]; then
     usage
 fi
 
@@ -45,6 +45,8 @@ fi
 [[ -f $SAXON_JAR ]] || die "Cannot find saxon: $SAXON_JAR"
 
 valid_serialization $SERIALIZATION || die "Invalid serialization: $SERIALIZATION"
+
+BN_ARG='usebnodes=false'
 
 # Note - saxon Xquery changes to xbin sub-directory, so we make all paths absolute
 # readlink also validates the paths
@@ -58,5 +60,5 @@ OUTPUT=`readlink -f $2`
 
 # Okay - run the conversion
 
-java -cp $SAXON_JAR net.sf.saxon.Query $MYDIR/../xbin/saxon.xqy marcxmluri="$MARCPATH" baseuri="$BASEURI" serialization="$SERIALIZATION" 1>$OUTPUT
+java -cp $SAXON_JAR net.sf.saxon.Query $MYDIR/../xbin/saxon.xqy marcxmluri="$MARCPATH" baseuri="$BASEURI" serialization="$SERIALIZATION" $BN_ARG 1>$OUTPUT
 

--- a/bin/convert-saxon.sh
+++ b/bin/convert-saxon.sh
@@ -51,10 +51,12 @@ BN_ARG='usebnodes=false'
 # Note - saxon Xquery changes to xbin sub-directory, so we make all paths absolute
 # readlink also validates the paths
 
-MARCPATH=`readlink -e $1`
+#MARCPATH=`readlink -e $1`
+MARCPATH=$1
 [[ -n "$MARCPATH" ]] || die "marcxml-input-path '$1' must exist"
 
-OUTPUT=`readlink -f $2`
+#OUTPUT=`readlink -f $2`
+OUTPUT=$2
 [[ -n "$OUTPUT" ]] || die "output-path '$2' all directory components must exist"
 
 


### PR DESCRIPTION
Two changes:
1.  I added usebnodes=false argument to the command to avoid this error:

net.sf.saxon.s9api.SaxonApiException: No value supplied for required parameter usebnodes
    at net.sf.saxon.s9api.XQueryEvaluator.run(XQueryEvaluator.java:370)
    at net.sf.saxon.Query.runQuery(Query.java:892)
    at net.sf.saxon.Query.doQuery(Query.java:439)
    at net.sf.saxon.Query.main(Query.java:111)
Caused by: net.sf.saxon.trans.XPathException: No value supplied for required parameter usebnodes
    at net.sf.saxon.expr.instruct.Executable.checkAllRequiredParamsArePresent(Executable.java:727)
    at net.sf.saxon.query.DynamicQueryContext.initializeController(DynamicQueryContext.java:419)
    at net.sf.saxon.query.XQueryExpression.newController(XQueryExpression.java:716)
    at net.sf.saxon.query.XQueryExpression.run(XQueryExpression.java:376)
    at net.sf.saxon.s9api.XQueryEvaluator.run(XQueryEvaluator.java:368)
    ... 3 more
Fatal error during query: net.sf.saxon.s9api.SaxonApiException: No value supplied for required parameter usebnodes
1.  I commented out calls to readlink as it is a utility that may not be installed on the machine running the script, or it may not have the -e or -f option (the problem on my mac).

The documentation could be changed to indicate absolute path is needed for the path args, or there may be another way to do this, such as something along these lines:

echo $(cd $(dirname "$1") && pwd -P)/$(basename "$1")

per http://stackoverflow.com/questions/5265702/how-to-get-full-path-of-a-file
See also  http://stackoverflow.com/questions/3915040/bash-fish-command-to-print-absolute-path-to-a-file/21188136#21188136
